### PR TITLE
Search rates by product name

### DIFF
--- a/lib/darkstore/rate.rb
+++ b/lib/darkstore/rate.rb
@@ -1,11 +1,12 @@
 module Darkstore
   class Rate < Api
-    def delivery_rates(darkstore_id: nil, zip:, cart:)
+    def delivery_rates(darkstore_id: nil, zip:, cart:, product_name: nil)
       params = {}
 
       params[:darkstore_id] = darkstore_id unless darkstore_id.nil?
       params[:order] = { zip: zip } unless zip.nil?
       params[:cart] = cart unless cart.nil?
+      params[:product_name] = true if product_name == true
 
       request(:get, 'delivery_rates', params: parse_json(params))
     end

--- a/lib/darkstore/response.rb
+++ b/lib/darkstore/response.rb
@@ -6,12 +6,17 @@ module Darkstore
 
     def initialize(underlying_response: nil, error_summary: nil)
       @response = underlying_response
-      @body = underlying_response.body
+
       @error_summary = error_summary
+      @body = if error_summary.nil?
+                underlying_response.body
+              else
+                { error: error_summary }.to_json
+              end
     end
 
     def ok?
-      response.status == 200
+      !response.nil? && response.status == 200
     end
 
     def json_response

--- a/spec/models/rate_spec.rb
+++ b/spec/models/rate_spec.rb
@@ -2,11 +2,28 @@ require 'spec_helper'
 
 RSpec.describe Darkstore::Rate, vcr: true do
   describe '#delivery_rates' do
-    subject { described_class.new.delivery_rates(zip: '02108', cart: { '1270' => 1 }) }
+    context "search by product id" do
+      subject { described_class.new.delivery_rates(zip: '11101', cart: { '1270' => 1 }) }
 
-    it "returns darkstore rates" do
-      expect(subject.ok?).to be_truthy
-      expect(subject.body).to include 'rates'
+      it "returns darkstore rates" do
+        expect(subject.ok?).to be_truthy
+        expect(subject.body).to include 'rates'
+      end
+    end
+
+    context "search by sku" do
+      subject do
+        described_class.new.delivery_rates(
+          zip: '11101',
+          cart: { 'FB-FBQ0' => 1 },
+          product_name: true
+        )
+      end
+
+      it "returns darkstore rates" do
+        expect(subject.ok?).to be_truthy
+        expect(subject.body).to include 'rates'
+      end
     end
   end
 end

--- a/spec/support/vcr_cassettes/Darkstore_Rate/_delivery_rates/search_by_product_id/returns_darkstore_rates.yml
+++ b/spec/support/vcr_cassettes/Darkstore_Rate/_delivery_rates/search_by_product_id/returns_darkstore_rates.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.darkstore.com/v1/api/delivery_rates?cart=%7B%221270%22:1%7D&order=%7B%22zip%22:%2202108%22%7D&product_name=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<Authorization Code>"
+      User-Agent:
+      - Faraday v0.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 15:49:10 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dc8c84c4926a171c9a1c21b7220167b6c1519228150; expires=Thu, 21-Feb-19
+        15:49:10 GMT; path=/; domain=.darkstore.com; HttpOnly; Secure
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3f0adaa449ee0e30-MXP
+    body:
+      encoding: UTF-8
+      string: Invalid token
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 15:49:10 GMT
+- request:
+    method: get
+    uri: https://www.darkstore.com/v1/api/delivery_rates?cart=%7B%221270%22:1%7D&order=%7B%22zip%22:%2211101%22%7D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<Authorization Code>"
+      User-Agent:
+      - Faraday v0.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 16:03:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d258437cdb7a3bfe672bbcf89803816821519228987; expires=Thu, 21-Feb-19
+        16:03:07 GMT; path=/; domain=.darkstore.com; HttpOnly; Secure
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"1c7-Kslevn7Si34p12v1zf5ehEAGDKc"
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3f0aef14eabd4316-MXP
+    body:
+      encoding: UTF-8
+      string: '{"rates":[{"delivery":"Same Day","carrier":"TForce","service":"SameDayWhiteGlove","rate":31.95,"delivery_date":"02/21","order_date":"2018-02-21T00:00:00+00:00","priority":2,"darkstore_location":"New
+        York City - TForce","darkstore_id":9},{"delivery":"Same Day","carrier":"TForce","service":"SameDay","rate":21.95,"delivery_date":"02/21","order_date":"2018-02-21T00:00:00+00:00","priority":2,"darkstore_location":"New
+        York City - TForce","darkstore_id":9}]}'
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 16:03:07 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/vcr_cassettes/Darkstore_Rate/_delivery_rates/search_by_product_name/returns_darkstore_rates.yml
+++ b/spec/support/vcr_cassettes/Darkstore_Rate/_delivery_rates/search_by_product_name/returns_darkstore_rates.yml
@@ -1,0 +1,111 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.darkstore.com/v1/api/delivery_rates?cart=%7B%22FB-FBQ0%22:1%7D&order=%7B%22zip%22:%2202108%22%7D&product_name=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<Authorization Code>"
+      User-Agent:
+      - Faraday v0.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 15:48:48 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dd1b7c9219000f2562fc693d64bd093851519228128; expires=Thu, 21-Feb-19
+        15:48:48 GMT; path=/; domain=.darkstore.com; HttpOnly; Secure
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3f0ada193af03dbf-MXP
+    body:
+      encoding: UTF-8
+      string: Invalid token
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 15:48:48 GMT
+- request:
+    method: get
+    uri: https://www.darkstore.com/v1/api/delivery_rates?cart=%7B%22FB-FBQ0%22:1%7D&order=%7B%22zip%22:%2211101%22%7D&product_name=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<Authorization Code>"
+      User-Agent:
+      - Faraday v0.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 Feb 2018 16:03:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=df2a4678811ba237694ea7e475093e7971519228988; expires=Thu, 21-Feb-19
+        16:03:08 GMT; path=/; domain=.darkstore.com; HttpOnly; Secure
+      X-Powered-By:
+      - Express
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"1c7-Kslevn7Si34p12v1zf5ehEAGDKc"
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3f0aef177c5d0e60-MXP
+    body:
+      encoding: UTF-8
+      string: '{"rates":[{"delivery":"Same Day","carrier":"TForce","service":"SameDayWhiteGlove","rate":31.95,"delivery_date":"02/21","order_date":"2018-02-21T00:00:00+00:00","priority":2,"darkstore_location":"New
+        York City - TForce","darkstore_id":9},{"delivery":"Same Day","carrier":"TForce","service":"SameDay","rate":21.95,"delivery_date":"02/21","order_date":"2018-02-21T00:00:00+00:00","priority":2,"darkstore_location":"New
+        York City - TForce","darkstore_id":9}]}'
+    http_version: 
+  recorded_at: Wed, 21 Feb 2018 16:03:08 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Darkstore has a product_name parameter that can be used to filter
shipping rates by product sku. This PR adds that parameter so that it
can be used
